### PR TITLE
Implement git checkout and git branch endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ dist
 .idea
 
 # User repositories
-repos
+repos/*
+!repos/scenarioDefaults

--- a/repos/scenarioDefaults/scenario-1/main.py
+++ b/repos/scenarioDefaults/scenario-1/main.py
@@ -1,0 +1,9 @@
+def very_important_function():
+    print("This is a very important function")
+    return True
+
+def main():
+    very_important_function()
+
+if __name__ == "__main__":
+    main()

--- a/repos/scenarioDefaults/test/main.py
+++ b/repos/scenarioDefaults/test/main.py
@@ -1,0 +1,9 @@
+def very_important_function():
+    print("This is a very important function")
+    return True
+
+def main():
+    very_important_function()
+
+if __name__ == "__main__":
+    main()

--- a/src/controllers/GitActionsController.ts
+++ b/src/controllers/GitActionsController.ts
@@ -177,4 +177,75 @@ async function push(req: Request, res: Response, next: NextFunction) {
   }
 }
 
-export default { initRepo, getRepoStatus, stageFile, stageAllFiles, stageAllAndCommit, commit, push };
+async function branch(req: Request, res: Response, next: NextFunction) {
+  Logger.info("branch run");
+
+  const {
+    username,
+    branchName,
+  }: { username: string; branchName: string } = req.body;
+
+  try {
+    const dir = getDefaultRepoDir(username);
+    const result = await git.branch({
+      fs,
+      dir,
+      ref: branchName,
+    });
+
+    res.status(HTTPStatusCode.CREATED).json(result);
+  } catch (e) {
+    Logger.error(e);
+    res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: "branch failed" });
+  }
+}
+
+async function checkout(req: Request, res: Response, next: NextFunction) {
+  Logger.info("checkout run");
+
+  const {
+    username,
+    branchName,
+  }: { username: string; branchName: string } = req.body;
+
+  try {
+    const dir = getDefaultRepoDir(username);
+    // TODO: an issue must arise when we try to checkout while having commits and changes. Address this issue.
+    const result = await git.checkout({
+      fs,
+      dir,
+      ref: branchName,
+    });
+
+    res.status(HTTPStatusCode.CREATED).json(result);
+  } catch (e) {
+    Logger.error(e);
+    res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: "checkout failed" });
+  }
+}
+
+// TODO: isomorphic-git doesn't have rebase. We need to implement this manually.
+// async function rebase(req: Request, res: Response, next: NextFunction) {
+//   Logger.info("rebase run");
+//
+//   const {
+//     username,
+//     branchName,
+//   }: { username: string; branchName: string } = req.body;
+//
+//   try {
+//     const dir = getDefaultRepoDir(username);
+//     const result = await git.rebase({
+//       fs,
+//       dir,
+//       ref: branchName,
+//     });
+//
+//     res.status(HTTPStatusCode.CREATED).json(result);
+//   } catch (e) {
+//     Logger.error(e);
+//     res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: "rebase failed" });
+//   }
+// }
+
+export default { initRepo, getRepoStatus, stageFile, stageAllFiles, stageAllAndCommit, commit, push, branch, checkout };

--- a/src/controllers/GitActionsController.ts
+++ b/src/controllers/GitActionsController.ts
@@ -182,21 +182,21 @@ async function branch(req: Request, res: Response, next: NextFunction) {
 
   const {
     username,
-    branchName,
-  }: { username: string; branchName: string } = req.body;
+    newBranchName,
+  }: { username: string; newBranchName: string } = req.body;
 
   try {
     const dir = getDefaultRepoDir(username);
-    const result = await git.branch({
+    await git.branch({
       fs,
       dir,
-      ref: branchName,
+      ref: newBranchName,
     });
 
-    res.status(HTTPStatusCode.CREATED).json(result);
-  } catch (e) {
+    res.sendStatus(HTTPStatusCode.CREATED);
+  } catch (e: any) {
     Logger.error(e);
-    res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: "branch failed" });
+    res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: e.code });
   }
 }
 
@@ -205,22 +205,22 @@ async function checkout(req: Request, res: Response, next: NextFunction) {
 
   const {
     username,
-    branchName,
-  }: { username: string; branchName: string } = req.body;
+    branch,
+  }: { username: string; branch: string } = req.body;
 
   try {
     const dir = getDefaultRepoDir(username);
     // TODO: an issue must arise when we try to checkout while having commits and changes. Address this issue.
-    const result = await git.checkout({
+    await git.checkout({
       fs,
       dir,
-      ref: branchName,
+      ref: branch,
     });
 
-    res.status(HTTPStatusCode.CREATED).json(result);
-  } catch (e) {
+    res.sendStatus(HTTPStatusCode.NO_CONTENT);
+  } catch (e: any) {
     Logger.error(e);
-    res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: "checkout failed" });
+    res.status(HTTPStatusCode.INTERNAL_SERVER_ERROR).json({ message: e.code });
   }
 }
 

--- a/src/controllers/ScenarioController.ts
+++ b/src/controllers/ScenarioController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Request, Response } from "express";
 import Scenario from "../models/Scenario";
 
 /**
@@ -12,20 +12,20 @@ import Scenario from "../models/Scenario";
  * @param next
  */
 const getScenarioByNameId = async (req: Request, res: Response, next: NextFunction) => {
-    const { nameId } = req.params;
-    const scenarioFromDB = await Scenario
-      .findOne({nameId})
-      .populate('segments.chats')
-      .populate('segments.notifications');
+  const { nameId } = req.params;
+  const scenarioFromDB = await Scenario
+    .findOne({ nameId })
+    .populate({ path: "segments.chats", populate: { path: "sender" } })
+    .populate("segments.notifications");
 
-    if (scenarioFromDB === null) {
-        res.status(404).send('Scenario not found');
-        return;
-    }
+  if (scenarioFromDB === null) {
+    res.status(404).send("Scenario not found");
+    return;
+  }
 
-    return res.status(200).json({ scenarioFromDB });
+  return res.status(200).json({ scenarioFromDB });
 };
 
 export default {
-    getScenarioByNameId,
+  getScenarioByNameId,
 };

--- a/src/routes/GitActionsRoutes.ts
+++ b/src/routes/GitActionsRoutes.ts
@@ -13,5 +13,7 @@ router.post("/stage-all", GitActionController.stageAllFiles);
 router.post("/stage-all-and-commit", GitActionController.stageAllAndCommit);
 router.post("/commit", GitActionController.commit);
 router.post("/push", GitActionController.push);
+router.post("/branch", GitActionController.branch);
+router.post("/checkout", GitActionController.checkout);
 
 export default router;


### PR DESCRIPTION
Added git checkout and git branch.
When an invalid request is sent, such as non-existent branch for git checkout or a pre-existing branch for git branch, an according error name is responded back to the request. 

Git rebase was deferred in implementation for now because there is no respective implementation in isomorphic git.
Methods in implementing it will later be discussed and implemented.

Fixes #41 