### PR TITLE
Rearrange hierarchy of github endpoints

### DIFF
--- a/src/routes/GitHubRoutes.ts
+++ b/src/routes/GitHubRoutes.ts
@@ -6,8 +6,8 @@ const router = express();
 router.get("/", (_, res) => {
     res.json({ message: "You are connected to backend github api" });
 });
-router.get("/:username/:pullNumber", GitHubController.checkPR);
-router.put("/update", GitHubController.updateGitHubDetails);
 router.get("/invite/:username", GitHubController.inviteToOrganization);
+router.put("/update", GitHubController.updateGitHubDetails);
+router.get("/checkPR/:username/:pullNumber", GitHubController.checkPR);
 
 export default router;


### PR DESCRIPTION
Now github endpoint checks invite first rather than being directed to checkPR link.